### PR TITLE
Fix by @jsgaobiao for BLAM installation issue #8 (ros/ros.h: No such …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 find_package(catkin REQUIRED)
 find_package(Eigen3 REQUIRED)
+find_package(catkin REQUIRED COMPONENTS roscpp)
 
 catkin_package(
   INCLUDE_DIRS
@@ -16,6 +17,7 @@ catkin_package(
 )
 
 include_directories(include ${EIGEN3_INCLUDE_DIR})
+include_directories(include ${catkin_INCLUDE_DIRS})
 
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}

--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,8 @@
 
   <build_depend>geometry_msgs</build_depend>
   <build_depend>tf2</build_depend>
+  <build_depend>roscpp</build_depend>
 
+  <run_depend>roscpp</run_depend>
   <run_depend>tf2</run_depend>
 </package>


### PR DESCRIPTION
 Fix by @jsgaobiao for BLAM installation issue #8 (ros/ros.h: No such file or directory) under ROS Kinetic. See: https://github.com/erik-nelson/blam/issues/8#issuecomment-268227234